### PR TITLE
fix: detail_bottom_screen의 TextField를 Text로 수정

### DIFF
--- a/lib/authentication/email_screen.dart
+++ b/lib/authentication/email_screen.dart
@@ -82,7 +82,7 @@ class _EmailScreenState extends State<EmailScreen> {
                 NextButton(
                   color:
                       _email.isNotEmpty && _isEmailValid() == null
-                          ? Colors.black
+                          ? Theme.of(context).primaryColor
                           : Colors.grey,
                   text: 'Next',
                   onPressed: () => _onSubmit(),

--- a/lib/authentication/login_form_screen.dart
+++ b/lib/authentication/login_form_screen.dart
@@ -35,7 +35,9 @@ class _LoginFormScreenState extends State<LoginFormScreen> {
     return GestureDetector(
       onTap: () => _onScaffoldTap(),
       child: Scaffold(
-        appBar: AppBar(title: Text('Log in')),
+        appBar: AppBar(
+          title: Text('로그인', style: Theme.of(context).textTheme.headlineSmall),
+        ),
         body: Center(
           child: Padding(
             padding: const EdgeInsets.symmetric(
@@ -50,7 +52,7 @@ class _LoginFormScreenState extends State<LoginFormScreen> {
                     height: 50,
                     child: TextFormField(
                       decoration: InputDecoration(
-                        hintText: 'Email',
+                        hintText: '이메일',
                         enabledBorder: UnderlineInputBorder(
                           borderSide: BorderSide(color: Colors.grey.shade400),
                         ),
@@ -77,7 +79,7 @@ class _LoginFormScreenState extends State<LoginFormScreen> {
                     height: 50,
                     child: TextFormField(
                       decoration: InputDecoration(
-                        hintText: 'Password',
+                        hintText: '비밀번호',
                         enabledBorder: UnderlineInputBorder(
                           borderSide: BorderSide(color: Colors.grey.shade400),
                         ),
@@ -100,8 +102,8 @@ class _LoginFormScreenState extends State<LoginFormScreen> {
                   ),
                   SizedBox(height: 28),
                   NextButton(
-                    color: Colors.black,
-                    text: 'Log in',
+                    color: Theme.of(context).primaryColor,
+                    text: '로그인',
                     onPressed: () => _onSubmit(),
                   ),
                 ],

--- a/lib/authentication/login_screen.dart
+++ b/lib/authentication/login_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:baseball_diary/authentication/widgets/auth_button.dart';
 import 'package:baseball_diary/authentication/widgets/next_button.dart';
-import 'package:baseball_diary/authentication/loginform_screen.dart';
+import 'package:baseball_diary/authentication/login_form_screen.dart';
 import 'package:baseball_diary/authentication/signup_screen.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -30,7 +30,9 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Log in')),
+      appBar: AppBar(
+        title: Text('로그인', style: Theme.of(context).textTheme.headlineSmall),
+      ),
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(20.0),
@@ -38,7 +40,7 @@ class _LoginScreenState extends State<LoginScreen> {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               SizedBox(height: 40),
-              FaIcon(FontAwesomeIcons.baseball, size: 50),
+              Icon(Icons.sports_baseball_sharp, size: 50),
               SizedBox(height: 80),
               GestureDetector(
                 onTap: () => _onEmailLoginTap(context),
@@ -62,13 +64,12 @@ class _LoginScreenState extends State<LoginScreen> {
         ),
       ),
       bottomNavigationBar: BottomAppBar(
-        color: Colors.grey[200],
         child: Padding(
           padding: const EdgeInsets.all(8.0),
           child: Center(
             child: NextButton(
               color: Colors.black,
-              text: 'Sign up',
+              text: '회원가입',
               onPressed: () => _onPressed(context),
             ),
           ),

--- a/lib/authentication/password_screen.dart
+++ b/lib/authentication/password_screen.dart
@@ -150,7 +150,10 @@ class _PasswordScreenState extends State<PasswordScreen> {
 
                 SizedBox(height: 40),
                 NextButton(
-                  color: _isPasswordValid() ? Colors.black : Colors.grey,
+                  color:
+                      _isPasswordValid()
+                          ? Theme.of(context).primaryColor
+                          : Colors.grey,
                   text: 'Next',
                   onPressed: () => _onSubmit(),
                 ),

--- a/lib/authentication/select_screen.dart
+++ b/lib/authentication/select_screen.dart
@@ -20,7 +20,10 @@ class SelectScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Select Team'), centerTitle: true),
+      appBar: AppBar(
+        title: Text('팀 선택', style: Theme.of(context).textTheme.headlineSmall),
+        centerTitle: true,
+      ),
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(30.0),
@@ -32,7 +35,7 @@ class SelectScreen extends StatelessWidget {
             itemBuilder: (context, index) {
               return GestureDetector(
                 onTap: () {
-                  Navigator.push(
+                  Navigator.pushReplacement(
                     context,
                     MaterialPageRoute(
                       builder: (context) => MainNavigationScreen(),
@@ -50,17 +53,11 @@ class SelectScreen extends StatelessWidget {
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Icon(
-                          Icons.sports_baseball_outlined,
-                          color: Colors.black87,
-                        ),
+                        Icon(Icons.sports_baseball_outlined),
                         SizedBox(width: 10),
                         Text(
                           teams[index],
-                          style: TextStyle(
-                            fontSize: 20,
-                            fontWeight: FontWeight.bold,
-                          ),
+                          style: Theme.of(context).textTheme.titleMedium,
                         ),
                       ],
                     ),

--- a/lib/authentication/signup_screen.dart
+++ b/lib/authentication/signup_screen.dart
@@ -21,7 +21,9 @@ class SignupScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Sign up')),
+      appBar: AppBar(
+        title: Text('회원가입', style: Theme.of(context).textTheme.headlineSmall),
+      ),
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(20.0),
@@ -29,7 +31,7 @@ class SignupScreen extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               SizedBox(height: 40),
-              FaIcon(FontAwesomeIcons.baseball, size: 50),
+              Icon(Icons.sports_baseball_sharp, size: 50),
               SizedBox(height: 80),
               GestureDetector(
                 onTap: () => _onEmailScreenTap(context),
@@ -53,13 +55,12 @@ class SignupScreen extends StatelessWidget {
         ),
       ),
       bottomNavigationBar: BottomAppBar(
-        color: Colors.grey[200],
         child: Padding(
           padding: const EdgeInsets.all(8.0),
           child: Center(
             child: NextButton(
               color: Colors.black,
-              text: 'Log in',
+              text: '로그인 페이지로 돌아가기',
               onPressed: () => _onPressed(context),
             ),
           ),

--- a/lib/authentication/widgets/auth_button.dart
+++ b/lib/authentication/widgets/auth_button.dart
@@ -19,7 +19,11 @@ class AuthButton extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
-          children: [FaIcon(icon, size: 25), SizedBox(width: 10), Text(text)],
+          children: [
+            FaIcon(icon, size: 25),
+            SizedBox(width: 10),
+            Text(text, style: Theme.of(context).textTheme.labelLarge),
+          ],
         ),
       ),
     );

--- a/lib/authentication/widgets/next_button.dart
+++ b/lib/authentication/widgets/next_button.dart
@@ -30,11 +30,9 @@ class NextButton extends StatelessWidget {
             children: [
               Text(
                 text,
-                style: TextStyle(
-                  fontSize: 16,
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                ),
+                style: Theme.of(
+                  context,
+                ).textTheme.titleMedium?.copyWith(color: Colors.white),
               ),
             ],
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:baseball_diary/main_navigation/main_navigation_screen.dart';
 import 'package:device_preview_plus/device_preview_plus.dart';
 import 'package:flutter/foundation.dart';
+import 'package:baseball_diary/authentication/login_screen.dart';
+import 'package:baseball_diary/authentication/select_screen.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 void main() => runApp(
   DevicePreview(
@@ -21,7 +24,74 @@ class MyApp extends StatelessWidget {
       locale: DevicePreview.locale(context),
       builder: DevicePreview.appBuilder,
       title: 'Flutter Demo',
+      themeMode: ThemeMode.system,
       theme: ThemeData(
+        textTheme: TextTheme(
+          displayLarge: GoogleFonts.gowunDodum(
+            fontSize: 96,
+            fontWeight: FontWeight.w300,
+            letterSpacing: -1.5,
+          ),
+          displayMedium: GoogleFonts.gowunDodum(
+            fontSize: 60,
+            fontWeight: FontWeight.w300,
+            letterSpacing: -0.5,
+          ),
+          displaySmall: GoogleFonts.gowunDodum(
+            fontSize: 48,
+            fontWeight: FontWeight.w500,
+          ),
+          headlineMedium: GoogleFonts.gowunDodum(
+            fontSize: 34,
+            fontWeight: FontWeight.w500,
+            letterSpacing: 0.25,
+          ),
+          headlineSmall: GoogleFonts.gowunDodum(
+            fontSize: 24,
+            fontWeight: FontWeight.w600,
+          ),
+          titleLarge: GoogleFonts.gowunDodum(
+            fontSize: 20,
+            fontWeight: FontWeight.w500,
+            letterSpacing: 0.15,
+          ),
+          titleMedium: GoogleFonts.gowunDodum(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.15,
+          ),
+          titleSmall: GoogleFonts.gowunDodum(
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+            letterSpacing: 0.1,
+          ),
+          bodyLarge: GoogleFonts.gowunDodum(
+            fontSize: 16,
+            fontWeight: FontWeight.w400,
+            letterSpacing: 0.5,
+          ),
+          bodyMedium: GoogleFonts.gowunDodum(
+            fontSize: 14,
+            fontWeight: FontWeight.w400,
+            letterSpacing: 0.25,
+          ),
+          labelLarge: GoogleFonts.gowunDodum(
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+            letterSpacing: 1.25,
+          ),
+          bodySmall: GoogleFonts.gowunDodum(
+            fontSize: 12,
+            fontWeight: FontWeight.w400,
+            letterSpacing: 0.4,
+          ),
+          labelSmall: GoogleFonts.gowunDodum(
+            fontSize: 10,
+            fontWeight: FontWeight.w400,
+            letterSpacing: 1.5,
+          ),
+        ),
+        brightness: Brightness.light,
         appBarTheme: AppBarTheme(
           backgroundColor: Colors.white,
           foregroundColor: Colors.black,
@@ -33,9 +103,91 @@ class MyApp extends StatelessWidget {
           ),
         ),
         scaffoldBackgroundColor: Colors.white,
-        primaryColor: Colors.black,
+        primaryColor: Color(0xFF1E2022),
+        bottomAppBarTheme: BottomAppBarTheme(color: Colors.white),
       ),
-      home: const MainNavigationScreen(),
+      darkTheme: ThemeData(
+        textTheme: TextTheme(
+          displayLarge: GoogleFonts.gowunDodum(
+            fontSize: 96,
+            fontWeight: FontWeight.w300,
+            letterSpacing: -1.5,
+          ),
+          displayMedium: GoogleFonts.gowunDodum(
+            fontSize: 60,
+            fontWeight: FontWeight.w300,
+            letterSpacing: -0.5,
+          ),
+          displaySmall: GoogleFonts.gowunDodum(
+            fontSize: 48,
+            fontWeight: FontWeight.w500,
+          ),
+          headlineMedium: GoogleFonts.gowunDodum(
+            fontSize: 34,
+            fontWeight: FontWeight.w500,
+            letterSpacing: 0.25,
+          ),
+          headlineSmall: GoogleFonts.gowunDodum(
+            fontSize: 24,
+            fontWeight: FontWeight.w600,
+          ),
+          titleLarge: GoogleFonts.gowunDodum(
+            fontSize: 20,
+            fontWeight: FontWeight.w500,
+            letterSpacing: 0.15,
+          ),
+          titleMedium: GoogleFonts.gowunDodum(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.15,
+          ),
+          titleSmall: GoogleFonts.gowunDodum(
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+            letterSpacing: 0.1,
+          ),
+          bodyLarge: GoogleFonts.gowunDodum(
+            fontSize: 16,
+            fontWeight: FontWeight.w400,
+            letterSpacing: 0.5,
+          ),
+          bodyMedium: GoogleFonts.gowunDodum(
+            fontSize: 14,
+            fontWeight: FontWeight.w400,
+            letterSpacing: 0.25,
+          ),
+          labelLarge: GoogleFonts.gowunDodum(
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+            letterSpacing: 1.25,
+          ),
+          bodySmall: GoogleFonts.gowunDodum(
+            fontSize: 12,
+            fontWeight: FontWeight.w400,
+            letterSpacing: 0.4,
+          ),
+          labelSmall: GoogleFonts.gowunDodum(
+            fontSize: 10,
+            fontWeight: FontWeight.w400,
+            letterSpacing: 1.5,
+          ),
+        ),
+        brightness: Brightness.dark,
+        appBarTheme: AppBarTheme(
+          backgroundColor: Colors.grey.shade900,
+          foregroundColor: Colors.white,
+          elevation: 0,
+          titleTextStyle: TextStyle(
+            color: Colors.white,
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        scaffoldBackgroundColor: Colors.black,
+        primaryColor: Color(0xFF52616A),
+        bottomAppBarTheme: BottomAppBarTheme(color: Colors.grey.shade900),
+      ),
+      home: LoginScreen(),
     );
   }
 }

--- a/lib/main_navigation/main_navigation_screen.dart
+++ b/lib/main_navigation/main_navigation_screen.dart
@@ -1,4 +1,5 @@
 import 'package:baseball_diary/menu/written_post.dart';
+import 'package:baseball_diary/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:baseball_diary/main_navigation/widget/nav_tab.dart';

--- a/lib/main_navigation/widget/detail_bottom_sheet.dart
+++ b/lib/main_navigation/widget/detail_bottom_sheet.dart
@@ -18,6 +18,7 @@ class _DetailBottomSheetState extends State<DetailBottomSheet> {
 
   void _onPressSave() {
     //TODO: 저장 로직 추가
+    //TODO: 저장하시겠습니까? 묻기
     Navigator.of(context).pop();
   }
 
@@ -36,7 +37,7 @@ class _DetailBottomSheetState extends State<DetailBottomSheet> {
           appBar: AppBar(
             title: Text('야구 일기'),
             actions: [
-              IconButton(onPressed: () {}, icon: Icon(Icons.edit)),
+              IconButton(onPressed: _onPressEdit, icon: Icon(Icons.edit)),
               IconButton(onPressed: _onPressDelete, icon: Icon(Icons.close)),
             ],
             centerTitle: true,
@@ -45,37 +46,25 @@ class _DetailBottomSheetState extends State<DetailBottomSheet> {
           body: Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                TextField(
-                  decoration: InputDecoration(hintText: 'title'),
-                  maxLines: 1,
+                Text(
+                  '제목',
                   style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                  cursorColor: Colors.black,
+                  maxLines: 1,
                   textAlign: TextAlign.start,
                 ),
-                TextField(
-                  decoration: InputDecoration(
-                    hintText: '여기에 클릭한 일기의 내용이 나오도록 해야함.',
-                  ),
-                  maxLines: 10,
+                Text(
+                  '여기에 클릭한 일기의 내용이 나오도록 해야함.',
                   style: TextStyle(fontSize: 14),
-                  cursorColor: Colors.black,
+                  maxLines: 10,
                   textAlign: TextAlign.start,
                 ),
-                Container(width: 100, height: 100, color: Colors.grey),
-                const SizedBox(height: 24),
-                SizedBox(
-                  width: double.infinity,
-                  height: 40,
-                  child: TextButton(
-                    onPressed: _onPressSave,
-                    style: TextButton.styleFrom(
-                      backgroundColor: Colors.black,
-                      foregroundColor: Colors.white,
-                    ),
-                    child: Text('완료'),
-                  ),
+                SizedBox(height: 16),
+                Center(
+                  child: Container(width: 200, height: 200, color: Colors.grey),
                 ),
+                const SizedBox(height: 24),
               ],
             ),
           ),

--- a/lib/main_navigation/widget/detail_bottom_sheet.dart
+++ b/lib/main_navigation/widget/detail_bottom_sheet.dart
@@ -35,7 +35,10 @@ class _DetailBottomSheetState extends State<DetailBottomSheet> {
       child: SafeArea(
         child: Scaffold(
           appBar: AppBar(
-            title: Text('야구 일기'),
+            title: Text(
+              '야구 일기',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
             actions: [
               IconButton(onPressed: _onPressEdit, icon: Icon(Icons.edit)),
               IconButton(onPressed: _onPressDelete, icon: Icon(Icons.close)),

--- a/lib/main_navigation/widget/nav_tab.dart
+++ b/lib/main_navigation/widget/nav_tab.dart
@@ -31,7 +31,9 @@ class NavTab extends StatelessWidget {
                 const SizedBox(height: 5),
                 Text(
                   text,
-                  style: const TextStyle(color: Colors.white, fontSize: 12),
+                  style: Theme.of(
+                    context,
+                  ).textTheme.labelSmall?.copyWith(color: Colors.white),
                 ),
               ],
             ),

--- a/lib/menu/write_post.dart
+++ b/lib/menu/write_post.dart
@@ -8,7 +8,10 @@ class WritePost extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false,
-        title: Text('오늘의 야구 일기'),
+        title: Text(
+          '오늘의 야구 일기',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
         centerTitle: true,
       ),
       body: SingleChildScrollView(

--- a/lib/menu/written_post.dart
+++ b/lib/menu/written_post.dart
@@ -18,7 +18,7 @@ class WrittenPost extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false,
-        title: Text('나의 야구 일기'),
+        title: Text('나의 야구 일기', style: Theme.of(context).textTheme.titleMedium),
         centerTitle: true,
       ),
       body: Column(

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,0 +1,4 @@
+import 'package:flutter/material.dart';
+
+bool isDarkMode(BuildContext context) =>
+    MediaQuery.of(context).platformBrightness == Brightness.dark;

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import path_provider_foundation
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -133,6 +141,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: "2776c66b3e97c6cdd58d1bd3281548b074b64f1fd5c8f82391f7456e38849567"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.5"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   intl:
     dependency: transitive
     description:
@@ -221,6 +253,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.17"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -378,6 +434,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   font_awesome_flutter: ^10.0.0
   device_preview_plus: ^2.3.4
+  google_fonts: ^4.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# 요약 및 목적
감정 일기를 만든 경험을 토대로 야구 경기를 관람하며 기분을 표현하고 내용을 작성할 수 있는 일기 애플리케이션을 만들고자 함.

# 변경 사항에 대한 설명
처음 written_post_screen에서 Container를 클릭시 바로 내용을 수정할 수 있도록 만들 생각이었으나, 클릭시에는 상세 페이지를 제공하고 수정 아이콘을 클릭할 경우에만 수정이 가능하도록 만들고자 함.

# 전달 내용
아직 낯설고 완벽하지 않아 부끄럽지만, 어떤 조언이든 달게 받습니다. 감사합니다.