### PR TITLE
Feat: 팀 선택 기능을 위한 MVVM 및 Provider 설정

### DIFF
--- a/lib/app/my_app.dart
+++ b/lib/app/my_app.dart
@@ -5,42 +5,32 @@ import 'package:baseball_diary/theme/app_theme.dart';
 import 'package:provider/provider.dart';
 import 'package:baseball_diary/select/viewmodels/select_viewmodels.dart';
 import 'package:baseball_diary/select/repos/select_repo.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:baseball_diary/core/preferences_service.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<SharedPreferences>(
-      future: SharedPreferences.getInstance(),
-      builder: (context, snapshot) {
-        if (!snapshot.hasData) {
-          return MaterialApp(
-            home: Scaffold(body: Center(child: CircularProgressIndicator())),
-          );
-        }
-
-        return MultiProvider(
-          providers: [
-            ChangeNotifierProvider(
-              create:
-                  (context) =>
-                      SelectViewModel(SelectRepository(snapshot.data!)),
-            ),
-          ],
-          child: MaterialApp.router(
-            routerConfig: router,
-            useInheritedMediaQuery: true,
-            locale: DevicePreview.locale(context),
-            builder: DevicePreview.appBuilder,
-            title: 'Flutter Demo',
-            themeMode: ThemeMode.system,
-            theme: AppTheme.lightTheme,
-            darkTheme: AppTheme.darkTheme,
-          ),
-        );
-      },
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create:
+              (context) => SelectViewModel(
+                SelectRepository(PreferencesService.preferences),
+              ),
+        ),
+      ],
+      child: MaterialApp.router(
+        routerConfig: router,
+        useInheritedMediaQuery: true,
+        locale: DevicePreview.locale(context),
+        builder: DevicePreview.appBuilder,
+        title: 'Flutter Demo',
+        themeMode: ThemeMode.system,
+        theme: AppTheme.lightTheme,
+        darkTheme: AppTheme.darkTheme,
+      ),
     );
   }
 }

--- a/lib/app/my_app.dart
+++ b/lib/app/my_app.dart
@@ -2,21 +2,45 @@ import 'package:flutter/material.dart';
 import 'package:device_preview_plus/device_preview_plus.dart';
 import 'package:baseball_diary/router.dart';
 import 'package:baseball_diary/theme/app_theme.dart';
+import 'package:provider/provider.dart';
+import 'package:baseball_diary/select/viewmodels/select_viewmodels.dart';
+import 'package:baseball_diary/select/repos/select_repo.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      routerConfig: router,
-      useInheritedMediaQuery: true,
-      locale: DevicePreview.locale(context),
-      builder: DevicePreview.appBuilder,
-      title: 'Flutter Demo',
-      themeMode: ThemeMode.system,
-      theme: AppTheme.lightTheme,
-      darkTheme: AppTheme.darkTheme,
+    return FutureBuilder<SharedPreferences>(
+      future: SharedPreferences.getInstance(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return MaterialApp(
+            home: Scaffold(body: Center(child: CircularProgressIndicator())),
+          );
+        }
+
+        return MultiProvider(
+          providers: [
+            ChangeNotifierProvider(
+              create:
+                  (context) =>
+                      SelectViewModel(SelectRepository(snapshot.data!)),
+            ),
+          ],
+          child: MaterialApp.router(
+            routerConfig: router,
+            useInheritedMediaQuery: true,
+            locale: DevicePreview.locale(context),
+            builder: DevicePreview.appBuilder,
+            title: 'Flutter Demo',
+            themeMode: ThemeMode.system,
+            theme: AppTheme.lightTheme,
+            darkTheme: AppTheme.darkTheme,
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/authentication/login_form_screen.dart
+++ b/lib/authentication/login_form_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:baseball_diary/authentication/widgets/next_button.dart';
-import 'package:baseball_diary/authentication/select_screen.dart';
+import 'package:baseball_diary/select/views/select_screen.dart';
 
 class LoginFormScreen extends StatefulWidget {
   const LoginFormScreen({super.key});

--- a/lib/authentication/password_screen.dart
+++ b/lib/authentication/password_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:baseball_diary/authentication/widgets/next_button.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:baseball_diary/authentication/select_screen.dart';
+import 'package:baseball_diary/select/views/select_screen.dart';
 
 class PasswordScreen extends StatefulWidget {
   const PasswordScreen({super.key});

--- a/lib/core/preferences_service.dart
+++ b/lib/core/preferences_service.dart
@@ -1,0 +1,16 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PreferencesService {
+  static SharedPreferences? _preferences;
+
+  static Future<void> init() async {
+    _preferences = await SharedPreferences.getInstance();
+  }
+
+  static SharedPreferences get preferences {
+    if (_preferences == null) {
+      throw Exception('PreferencesService not initialized');
+    }
+    return _preferences!;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:device_preview_plus/device_preview_plus.dart';
 import 'package:flutter/foundation.dart';
-import 'package:baseball_diary/app/my_app.dart';
+import 'package:baseball_diary/screens/splash_screen.dart';
 
-void main() => runApp(
-  DevicePreview(enabled: !kReleaseMode, builder: (context) => const MyApp()),
-);
+void main() {
+  runApp(
+    DevicePreview(
+      enabled: !kReleaseMode,
+      builder: (context) => const MaterialApp(home: SplashScreen()),
+    ),
+  );
+}

--- a/lib/main_navigation/main_navigation_screen.dart
+++ b/lib/main_navigation/main_navigation_screen.dart
@@ -1,5 +1,4 @@
 import 'package:baseball_diary/menu/written_post.dart';
-import 'package:baseball_diary/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:baseball_diary/main_navigation/widget/nav_tab.dart';

--- a/lib/route_const.dart
+++ b/lib/route_const.dart
@@ -1,4 +1,4 @@
-const String selectRoute = '/select';
+const String selectRoute = '/';
 const String mainNavigationRoute = '/main';
 
 const String selectRouteName = 'select';

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,5 +1,5 @@
 import 'package:go_router/go_router.dart';
-import 'package:baseball_diary/authentication/select_screen.dart';
+import 'package:baseball_diary/select/views/select_screen.dart';
 import 'package:baseball_diary/main_navigation/main_navigation_screen.dart';
 import 'route_const.dart';
 

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:baseball_diary/core/preferences_service.dart';
+import 'package:baseball_diary/app/my_app.dart';
+
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    await PreferencesService.init();
+    // 필요한 경우 여기에 다른 초기화 작업 추가
+    await Future.delayed(const Duration(seconds: 2));
+
+    if (mounted) {
+      Navigator.of(
+        context,
+      ).pushReplacement(MaterialPageRoute(builder: (context) => const MyApp()));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // 여기에 앱 로고나 이미지 추가
+            const CircularProgressIndicator(),
+            const SizedBox(height: 16),
+            const Text('로딩 중...'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/select/models/select_models.dart
+++ b/lib/select/models/select_models.dart
@@ -1,0 +1,14 @@
+class SelectModel {
+  final List<String> teams = [
+    'KIA 타이거즈',
+    '롯데 자이언츠',
+    '두산 베어스',
+    '삼성 라이온즈',
+    '한화 이글스',
+    '키움 히어로즈',
+    'KT 위즈',
+    'LG 트윈스',
+    'NC 다이노스',
+    'SSG 랜더스',
+  ];
+}

--- a/lib/select/repos/select_repo.dart
+++ b/lib/select/repos/select_repo.dart
@@ -9,7 +9,7 @@ class SelectRepository {
     await _preferences.setString('team', team);
   }
 
-  Future<String> getTeam() async {
+  String getTeam() {
     return _preferences.getString('team') ?? '';
   }
 }

--- a/lib/select/repos/select_repo.dart
+++ b/lib/select/repos/select_repo.dart
@@ -1,0 +1,15 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SelectRepository {
+  final SharedPreferences _preferences;
+
+  SelectRepository(this._preferences);
+
+  Future<void> saveTeam(String team) async {
+    await _preferences.setString('team', team);
+  }
+
+  Future<String> getTeam() async {
+    return _preferences.getString('team') ?? '';
+  }
+}

--- a/lib/select/viewmodels/select_viewmodels.dart
+++ b/lib/select/viewmodels/select_viewmodels.dart
@@ -14,5 +14,9 @@ class SelectViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<String> getTeam() async {
+    return await _repository.getTeam();
+  }
+
   List<String> get teams => _teams;
 }

--- a/lib/select/viewmodels/select_viewmodels.dart
+++ b/lib/select/viewmodels/select_viewmodels.dart
@@ -1,0 +1,3 @@
+import 'package:flutter/material.dart';
+
+class SelectViewModel extends ChangeNotifier {}

--- a/lib/select/viewmodels/select_viewmodels.dart
+++ b/lib/select/viewmodels/select_viewmodels.dart
@@ -14,8 +14,8 @@ class SelectViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<String> getTeam() async {
-    return await _repository.getTeam();
+  String getTeam() {
+    return _repository.getTeam();
   }
 
   List<String> get teams => _teams;

--- a/lib/select/viewmodels/select_viewmodels.dart
+++ b/lib/select/viewmodels/select_viewmodels.dart
@@ -1,3 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:baseball_diary/select/repos/select_repo.dart';
+import 'package:baseball_diary/select/models/select_models.dart';
 
-class SelectViewModel extends ChangeNotifier {}
+class SelectViewModel extends ChangeNotifier {
+  final SelectRepository _repository;
+
+  late final List<String> _teams = SelectModel().teams;
+
+  SelectViewModel(this._repository);
+
+  Future<void> setTeam(String team) async {
+    await _repository.saveTeam(team);
+    notifyListeners();
+  }
+
+  List<String> get teams => _teams;
+}

--- a/lib/select/views/select_screen.dart
+++ b/lib/select/views/select_screen.dart
@@ -1,24 +1,12 @@
 import 'package:baseball_diary/main_navigation/main_navigation_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:baseball_diary/select/models/select_models.dart';
 
 class SelectScreen extends StatelessWidget {
   static const String routeName = '/';
 
-  SelectScreen({super.key});
-
-  final List<String> teams = [
-    'KIA 타이거즈',
-    '롯데 자이언츠',
-    '두산 베어스',
-    '삼성 라이온즈',
-    '한화 이글스',
-    '키움 히어로즈',
-    'KT 위즈',
-    'LG 트윈스',
-    'NC 다이노스',
-    'SSG 랜더스',
-  ];
+  const SelectScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +22,7 @@ class SelectScreen extends StatelessWidget {
             separatorBuilder: (context, index) {
               return SizedBox(height: 15);
             },
-            itemCount: teams.length,
+            itemCount: SelectModel().teams.length,
             itemBuilder: (context, index) {
               return GestureDetector(
                 onTap: () {
@@ -54,7 +42,7 @@ class SelectScreen extends StatelessWidget {
                         Icon(Icons.sports_baseball_outlined),
                         SizedBox(width: 10),
                         Text(
-                          teams[index],
+                          SelectModel().teams[index],
                           style: Theme.of(context).textTheme.titleMedium,
                         ),
                       ],

--- a/lib/select/views/select_screen.dart
+++ b/lib/select/views/select_screen.dart
@@ -1,7 +1,8 @@
 import 'package:baseball_diary/main_navigation/main_navigation_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:baseball_diary/select/models/select_models.dart';
+import 'package:baseball_diary/select/viewmodels/select_viewmodels.dart';
+import 'package:provider/provider.dart';
 
 class SelectScreen extends StatelessWidget {
   static const String routeName = '/';
@@ -18,37 +19,53 @@ class SelectScreen extends StatelessWidget {
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(30.0),
-          child: ListView.separated(
-            separatorBuilder: (context, index) {
-              return SizedBox(height: 15);
-            },
-            itemCount: SelectModel().teams.length,
-            itemBuilder: (context, index) {
-              return GestureDetector(
-                onTap: () {
-                  context.go(MainNavigationScreen.routeName);
+          child: Consumer<SelectViewModel>(
+            builder: (context, viewModel, child) {
+              return ListView.separated(
+                separatorBuilder: (context, index) {
+                  return SizedBox(height: 15);
                 },
-                child: Container(
-                  decoration: BoxDecoration(
-                    border: Border.all(color: Colors.grey),
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  width: 340,
-                  height: 50,
-                  child: Center(
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(Icons.sports_baseball_outlined),
-                        SizedBox(width: 10),
-                        Text(
-                          SelectModel().teams[index],
-                          style: Theme.of(context).textTheme.titleMedium,
+                itemCount: viewModel.teams.length,
+                itemBuilder: (context, index) {
+                  return GestureDetector(
+                    onTap: () async {
+                      await viewModel.setTeam(viewModel.teams[index]);
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              '${viewModel.teams[index]}가 선택되었습니다.',
+                            ),
+                            duration: Duration(seconds: 2),
+                            behavior: SnackBarBehavior.floating,
+                          ),
+                        );
+                        context.go(MainNavigationScreen.routeName);
+                      }
+                    },
+                    child: Container(
+                      decoration: BoxDecoration(
+                        border: Border.all(color: Colors.grey),
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      width: 340,
+                      height: 50,
+                      child: Center(
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(Icons.sports_baseball_outlined),
+                            SizedBox(width: 10),
+                            Text(
+                              viewModel.teams[index],
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                          ],
                         ),
-                      ],
+                      ),
                     ),
-                  ),
-                ),
+                  );
+                },
               );
             },
           ),

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -2,40 +2,82 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 class AppTheme {
+  // 라이트 모드 색상 팔레트
+  static const Color lightBackgroundColor = Colors.white;
+  static const Color lightSurfaceColor = Color(0xFFF5F5F5);
+  static const Color lightPrimaryColor = Color(0xFF1E2022);
+  static const Color lightTextColor = Colors.black87;
+  static const Color lightAccentColor = Colors.blueAccent;
+  static const Color lightErrorColor = Color(0xFFB00020);
+  static const Color lightSuccessColor = Color(0xFF4CAF50);
+  static const Color lightWarningColor = Color(0xFFFFC107);
+  static const Color lightDisabledColor = Color(0xFF9E9E9E);
+
+  // 다크 모드 색상 팔레트
+  static const Color darkBackgroundColor = Color(0xFF121212);
+  static const Color darkSurfaceColor = Color(0xFF1E1E1E);
+  static const Color darkPrimaryColor = Color(0xFF52616A);
+  static const Color darkTextColor = Colors.white;
+  static const Color darkAccentColor = Colors.lightBlueAccent;
+  static const Color darkErrorColor = Color(0xFFCF6679);
+  static const Color darkSuccessColor = Color(0xFF81C784);
+  static const Color darkWarningColor = Color(0xFFFFD54F);
+  static const Color darkDisabledColor = Color(0xFF757575);
+
   static ThemeData lightTheme = ThemeData(
     brightness: Brightness.light,
     textTheme: _textTheme(),
     appBarTheme: const AppBarTheme(
-      backgroundColor: Colors.white,
-      foregroundColor: Colors.black,
+      backgroundColor: lightBackgroundColor,
+      foregroundColor: lightTextColor,
       elevation: 0,
       titleTextStyle: TextStyle(
-        color: Colors.black,
+        color: lightTextColor,
         fontSize: 18,
         fontWeight: FontWeight.bold,
       ),
     ),
-    scaffoldBackgroundColor: Colors.white,
-    primaryColor: const Color(0xFF1E2022),
-    bottomAppBarTheme: const BottomAppBarTheme(color: Colors.white),
+    scaffoldBackgroundColor: lightBackgroundColor,
+    primaryColor: lightPrimaryColor,
+    bottomAppBarTheme: const BottomAppBarTheme(color: lightBackgroundColor),
+    colorScheme: ColorScheme.light(
+      surface: lightSurfaceColor,
+      primary: lightPrimaryColor,
+      secondary: lightAccentColor,
+      error: lightErrorColor,
+      onSurface: lightTextColor,
+      onPrimary: Colors.white,
+      onSecondary: Colors.white,
+      onError: Colors.white,
+    ),
   );
 
   static ThemeData darkTheme = ThemeData(
     brightness: Brightness.dark,
     textTheme: _textTheme(),
-    appBarTheme: AppBarTheme(
-      backgroundColor: Colors.grey.shade900,
-      foregroundColor: Colors.white,
+    appBarTheme: const AppBarTheme(
+      backgroundColor: darkBackgroundColor,
+      foregroundColor: darkTextColor,
       elevation: 0,
-      titleTextStyle: const TextStyle(
-        color: Colors.white,
+      titleTextStyle: TextStyle(
+        color: darkTextColor,
         fontSize: 18,
         fontWeight: FontWeight.bold,
       ),
     ),
-    scaffoldBackgroundColor: Colors.black,
-    primaryColor: const Color(0xFF52616A),
-    bottomAppBarTheme: BottomAppBarTheme(color: Colors.grey.shade900),
+    scaffoldBackgroundColor: darkBackgroundColor,
+    primaryColor: darkPrimaryColor,
+    bottomAppBarTheme: const BottomAppBarTheme(color: darkBackgroundColor),
+    colorScheme: ColorScheme.dark(
+      surface: darkSurfaceColor,
+      primary: darkPrimaryColor,
+      secondary: darkAccentColor,
+      error: darkErrorColor,
+      onSurface: darkTextColor,
+      onPrimary: Colors.white,
+      onSecondary: Colors.white,
+      onError: Colors.white,
+    ),
   );
 
   static TextTheme _textTheme() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   font_awesome_flutter: ^10.0.0
   device_preview_plus: ^2.3.4
   google_fonts: ^4.0.1
-  shared_preferences: ^2.0.17
+  shared_preferences: ^2.5.3
   flutter_riverpod: ^2.1.3
   go_router: ^6.0.2
 


### PR DESCRIPTION
## 구현 내용
- SelectViewModel을 통한 팀 선택 기능 구현
- SharedPreferences를 사용한 팀 데이터 영구 저장 기능 추가
- Provider 패턴을 적용하여 상태 관리 구조 개선
- SnackBar를 통한 팀 선택 피드백 UI 추가

## 주요 변경사항
1. SelectViewModel
   - 팀 선택 및 저장 로직 구현
   - 비동기 처리를 위한 Future 적용

2. SelectScreen
   - Provider Consumer 패턴 적용
   - 팀 선택 시 시각적 피드백 추가 (SnackBar)

3. MyApp
   - Provider 설정 및 의존성 주입 구조 구현
   - SharedPreferences 초기화 로직 추가
   
 ## 전달 내용
 아직 공부가 부족하여 RIVERPOD으로 구현하지 못했습니다.
 MVVM은 이렇게 하는게 맞는거겠지요.......
 열심히 강의 들으면서 + AI의 도움을 받아가며 공부하는 중입니다... 